### PR TITLE
Bugfix/issue 4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,7 +74,3 @@ crashlytics-build.properties
 /[Aa]ssets/[Ss]treamingAssets/aa/*
 
 Records
-
-CHANGELOG.md.meta
-LICENSE.meta
-README.md.meta

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Fixed issue [#4](https://github.com/liris-xr/PLUME-Recorder/issues/4) where the `Object.Instantiate(T obj, Scene scene)` function was causing a compilation error in Unity 2023 (missing from the Unity 2023 API).
+
 ## [1.2.1-beta]
 
 ### Fixed

--- a/CHANGELOG.md.meta
+++ b/CHANGELOG.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 00693299986531b479e6777dee312204
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/LICENSE.meta
+++ b/LICENSE.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 24493af11dcbcbc4081682e95784b9d8
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/README.md.meta
+++ b/README.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 2683edd897735184d976071c34ec96a6
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Base/Hooks/ObjectHooks.cs
+++ b/Runtime/Base/Hooks/ObjectHooks.cs
@@ -53,20 +53,7 @@ namespace PLUME.Base.Hooks
                 typeof(ObjectHooks).GetMethod(nameof(InstantiateAndNotify), new[] { typeof(Object) }),
                 typeof(Object).GetMethod(nameof(Object.Instantiate), new[] { typeof(Object) })
             );
-
-            var instantiateWithSceneParamMethod =
-                typeof(Object).GetMethod(nameof(Object.Instantiate), new[] { typeof(Object), typeof(Scene) });
-
-            // This method was introduced in one of the patch of Unity 2022. We need to check if it exists before adding a hook for it.
-            if (instantiateWithSceneParamMethod != null)
-            {
-                hooksRegistry.RegisterHook(
-                    typeof(ObjectHooks).GetMethod(nameof(InstantiateAndNotify),
-                        new[] { typeof(Object), typeof(Scene) }),
-                    instantiateWithSceneParamMethod
-                );
-            }
-
+            
             hooksRegistry.RegisterHook(
                 typeof(ObjectHooks).GetMethod(nameof(InstantiateAndNotify),
                     new[] { typeof(Object), typeof(Transform) }),
@@ -273,13 +260,6 @@ namespace PLUME.Base.Hooks
         public static Object InstantiateAndNotify(Object original, Transform parent)
         {
             var instance = Object.Instantiate(original, parent);
-            NotifyInstantiated(instance);
-            return instance;
-        }
-
-        public static Object InstantiateAndNotify(Object original, Scene scene)
-        {
-            var instance = Object.Instantiate(original, scene);
             NotifyInstantiated(instance);
             return instance;
         }


### PR DESCRIPTION
### Fixed

- Fixed issue [#4](https://github.com/liris-xr/PLUME-Recorder/issues/4) where the `Object.Instantiate(T obj, Scene scene)` function was causing a compilation error in Unity 2023 (missing from the Unity 2023 API). As this function was introduced in one of Unity's 2022 patch and isn't documented anywhere in the official documentation, we drop the support for this function for now.