### PR TITLE
Add version switch for XRITK to work with 2.x and 3.x

### DIFF
--- a/Runtime/PLUME.Recorder.asmdef
+++ b/Runtime/PLUME.Recorder.asmdef
@@ -34,8 +34,13 @@
         },
         {
             "name": "com.unity.xr.interaction.toolkit",
-            "expression": "0",
-            "define": "XRITK_ENABLED"
+            "expression": "[2.0,3.0)",
+            "define": "USE_XRITK_2"
+        },
+        {
+            "name": "com.unity.xr.interaction.toolkit",
+            "expression": "[3.0,4.0)",
+            "define": "USE_XRITK_3"
         },
         {
             "name": "com.unity.textmeshpro",


### PR DESCRIPTION
- Ensure XRITK compatibility for v2 and v3 by adding a macro to automatically switch between version 2.x and 3.x in the XRBaseInteractableRecorderModule and XRBaseInteractorRecorderModule.
 