### PR TITLE
v1.2.3-beta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.3-beta]
+
+### Fixed
+
+- Fix issue when SkinnedMeshRenderer sharedMesh is null, causing the recorder to fail with a NPE.
+
+### Added
+
+- Ensure XRITK compatibility for v2 and v3 by adding a macro to automatically switch between version 2.x and 3.x in the XRBaseInteractableRecorderModule and XRBaseInteractorRecorderModule.
+
 ## [1.2.2-beta]
 
 ### Fixed

--- a/Runtime/Base/Module/Unity/Renderer/SkinnedMeshRendererModule/SkinnedMeshRendererRecorderModule.cs
+++ b/Runtime/Base/Module/Unity/Renderer/SkinnedMeshRendererModule/SkinnedMeshRendererRecorderModule.cs
@@ -41,22 +41,28 @@ namespace PLUME.Base.Module.Unity.Renderer.SkinnedMeshRendererModule
             updateSample.RootBoneId = GetComponentIdentifierPayload(rootBoneRef);
             updateSample.Bones = new SkinnedMeshRendererUpdate.Types.Bones();
 
-            foreach (var bone in objSafeRef.Component.bones)
+            if (objSafeRef.Component.bones != null)
             {
-                var boneRef = ctx.ObjectSafeRefProvider.GetOrCreateComponentSafeRef(bone);
-                updateSample.Bones.Ids.Add(GetComponentIdentifierPayload(boneRef));
+                foreach (var bone in objSafeRef.Component.bones)
+                {
+                    var boneRef = ctx.ObjectSafeRefProvider.GetOrCreateComponentSafeRef(bone);
+                    updateSample.Bones.Ids.Add(GetComponentIdentifierPayload(boneRef));
+                }
             }
 
             updateSample.BlendShapeWeights = new SkinnedMeshRendererUpdate.Types.BlendShapeWeights();
 
-            for (var i = 0; i < objSafeRef.Component.sharedMesh.blendShapeCount; i++)
+            if (objSafeRef.Component.sharedMesh != null)
             {
-                updateSample.BlendShapeWeights.Weights.Add(
-                    new SkinnedMeshRendererUpdate.Types.BlendShapeWeights.Types.BlendShapeWeight
-                    {
-                        Index = i,
-                        Weight = objSafeRef.Component.GetBlendShapeWeight(i)
-                    });
+                for (var i = 0; i < objSafeRef.Component.sharedMesh.blendShapeCount; i++)
+                {
+                    updateSample.BlendShapeWeights.Weights.Add(
+                        new SkinnedMeshRendererUpdate.Types.BlendShapeWeights.Types.BlendShapeWeight
+                        {
+                            Index = i,
+                            Weight = objSafeRef.Component.GetBlendShapeWeight(i)
+                        });
+                }
             }
 
             _createSamples[objSafeRef] = new SkinnedMeshRendererCreate

--- a/Runtime/Core/Recorder/Recorder.cs
+++ b/Runtime/Core/Recorder/Recorder.cs
@@ -31,7 +31,7 @@ namespace PLUME.Core.Recorder
             Name = "PLUME Recorder (Beta)",
             Major = "1",
             Minor = "2",
-            Patch = "2",
+            Patch = "3",
         };
 
         private readonly RecorderContext _context;

--- a/Runtime/PLUME.Recorder.asmdef
+++ b/Runtime/PLUME.Recorder.asmdef
@@ -34,8 +34,13 @@
         },
         {
             "name": "com.unity.xr.interaction.toolkit",
-            "expression": "0",
-            "define": "XRITK_ENABLED"
+            "expression": "[2.0,3.0)",
+            "define": "USE_XRITK_2"
+        },
+        {
+            "name": "com.unity.xr.interaction.toolkit",
+            "expression": "[3.0,4.0)",
+            "define": "USE_XRITK_3"
         },
         {
             "name": "com.unity.textmeshpro",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fr.liris.plume.recorder",
-  "version": "1.2.2-beta",
+  "version": "1.2.3-beta",
   "displayName": "PLUME-Recorder",
   "description": "PLUME: PLugin for Unity to Monitor Experiments",
   "unity": "2022.3",


### PR DESCRIPTION
### Fixed

- Fix issue when SkinnedMeshRenderer sharedMesh is null, causing the recorder to fail with a NPE.

### Added

- Ensure XRITK compatibility for v2 and v3 by adding a macro to automatically switch between version 2.x and 3.x in the XRBaseInteractableRecorderModule and XRBaseInteractorRecorderModule.
