### PR TITLE
v3.0.1

### DIFF
--- a/Runtime/Base/Module/Unity/Transform/DynamicTransformAccessArray.cs
+++ b/Runtime/Base/Module/Unity/Transform/DynamicTransformAccessArray.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Collections.Generic;
-using PLUME.Core.Object;
+using PLUME.Core;
 using PLUME.Core.Object.SafeRef;
 using PLUME.Sample.ProtoBurst.Unity;
 using Unity.Collections;
@@ -104,21 +104,22 @@ namespace PLUME.Base.Module.Unity.Transform
         }
 
         /// <summary>
-        /// Removes the given transform from the list and return. Throws an exception if the transform is not in the list.
+        /// Removes the given transform from the list and return.
         /// Might change the order of elements in the buffer as it swaps the last element with the one to remove.
         /// </summary>
         /// <param name="objRef">The transform to remove.</param>
-        /// <exception cref="InvalidOperationException">Thrown if the transform is not in the list.</exception>
-        /// <returns>The index of the removed transform.</returns>
-        public int RemoveSwapBack(IComponentSafeRef<UnityEngine.Transform> objRef)
+        /// <param name="index">The index where the transform was removed, or -1 if no object was removed.</param>
+        /// <returns>True if the transform was removed, false otherwise.</returns>
+        public bool TryRemoveSwapBack(IComponentSafeRef<UnityEngine.Transform> objRef, out int index)
         {
-            var index = IndexOf(objRef);
+            index = IndexOf(objRef);
 
+            // If the object is not in the list, we do not need to do anything
             if (index == -1)
-                throw new InvalidOperationException($"Transform {objRef.Component.name} is not in the list");
+                return false;
 
             RemoveAtSwapBack(index);
-            return index;
+            return true;
         }
 
         /// <summary>

--- a/Runtime/Base/Module/Unity/Transform/TransformRecorderModule.cs
+++ b/Runtime/Base/Module/Unity/Transform/TransformRecorderModule.cs
@@ -133,11 +133,13 @@ namespace PLUME.Base.Module.Unity.Transform
         {
             base.OnStopRecordingObject(tSafeRef, ctx);
             var lastIdentifier = _transformAccessArray.GetAlignedIdentifiers()[^1];
+
+            // If the object is not in the list, we don't need to do anything
+            if (!_transformAccessArray.TryRemoveSwapBack(tSafeRef, out var idx))
+                return;
             
-            var idx = _transformAccessArray.RemoveSwapBack(tSafeRef);
             _alignedStates.RemoveAtSwapBack(idx);
-            
-            // Update the index of the swapped element
+            // As we swapped the removed element with the last one, we need to update the index of the last element
             _identifierToIndex[lastIdentifier] = idx;
         }
 

--- a/Runtime/Core/Recorder/Recorder.cs
+++ b/Runtime/Core/Recorder/Recorder.cs
@@ -32,7 +32,7 @@ namespace PLUME.Core.Recorder
             Name = "PLUME Recorder (Beta)",
             Major = "3",
             Minor = "0",
-            Patch = "0",
+            Patch = "1",
         };
 
         private readonly RecorderContext _context;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fr.liris.plume.recorder",
-  "version": "3.0.0-beta",
+  "version": "3.0.1-beta",
   "displayName": "PLUME-Recorder",
   "description": "PLUME: PLugin for Unity to Monitor Experiments",
   "unity": "2022.3",


### PR DESCRIPTION
This fix resolves #13 where MissingReferenceException could be thrown during transform access in the DynamicTransformAccessArray.RemoveSwapBack function.