### PR TITLE
support configurable output data writers in recorder

### DIFF
--- a/Runtime/Core/Recorder/Module/Frame/FrameRecorderModule.cs
+++ b/Runtime/Core/Recorder/Module/Frame/FrameRecorderModule.cs
@@ -61,6 +61,7 @@ namespace PLUME.Core.Recorder.Module.Frame
         void IRecorderModule.StartRecording(RecorderContext ctx)
         {
             _lastUpdateTime = 0;
+            _lastFixedUpdateTime = ctx.CurrentRecord.Time;
             _shouldRunUpdate = true;
             _shouldSerialize = true;
 

--- a/Runtime/Core/Recorder/Recorder.cs
+++ b/Runtime/Core/Recorder/Recorder.cs
@@ -77,7 +77,11 @@ namespace PLUME.Core.Recorder
 
             if (outputs == null)
             {
-                IDataWriter fileDataWriter = new FileDataWriter();
+                var outputDir = Application.persistentDataPath;
+
+                FileDataWriter.GenerateFilePath(outputDir, name, out string filePath, out string metaFilePath);
+
+                IDataWriter fileDataWriter = new FileDataWriter(filePath, metaFilePath);
                 outputs = new IDataWriter[] { fileDataWriter };
             }
 
@@ -85,7 +89,7 @@ namespace PLUME.Core.Recorder
 
             foreach (IDataWriter output in outputs)
             {
-                output.Initialize(record);
+                output.SetMetaData(recordMetadata);
             }
 
             _dataDispatcher.Start(_context.CurrentRecord, outputs);

--- a/Runtime/Core/Recorder/RecorderExtensions.cs
+++ b/Runtime/Core/Recorder/RecorderExtensions.cs
@@ -29,10 +29,10 @@ namespace PLUME.Core.Recorder
                 throw new InvalidOperationException("PLUME recorder instance is not created yet.");
         }
 
-        public static void StartRecording(string name, string extraMetadata = "")
+        public static void StartRecording(string name, string extraMetadata = "", IDataWriterInfo[] dataWriterInfos = null)
         {
             CheckInstantiated();
-            Instance.StartRecordingInternal(name, extraMetadata);
+            Instance.StartRecordingInternal(name, extraMetadata, dataWriterInfos);
         }
 
         public static async UniTask StopRecording()

--- a/Runtime/Core/Recorder/RecorderExtensions.cs
+++ b/Runtime/Core/Recorder/RecorderExtensions.cs
@@ -29,10 +29,10 @@ namespace PLUME.Core.Recorder
                 throw new InvalidOperationException("PLUME recorder instance is not created yet.");
         }
 
-        public static void StartRecording(string name, string extraMetadata = "", IDataWriterInfo[] dataWriterInfos = null)
+        public static void StartRecording(string name, string extraMetadata = "", IDataWriter[] writers = null)
         {
             CheckInstantiated();
-            Instance.StartRecordingInternal(name, extraMetadata, dataWriterInfos);
+            Instance.StartRecordingInternal(name, extraMetadata, writers);
         }
 
         public static async UniTask StopRecording()

--- a/Runtime/Core/Recorder/Writer/DataDispatcher.cs
+++ b/Runtime/Core/Recorder/Writer/DataDispatcher.cs
@@ -11,16 +11,12 @@ namespace PLUME.Core.Recorder.Writer
         private bool _running;
         private Thread _dispatcherThread;
 
-        private IDataWriter[] _outputs;
+        private IDataWriter<IDataWriterInfo>[] _outputs;
         private NetworkStream _networkStream;
 
-        internal void Start(Record record)
+        internal void Start(Record record, IDataWriter<IDataWriterInfo>[] outputs)
         {
-            var fileDataWriter = new FileDataWriter(record);
-            _outputs = new IDataWriter[] { fileDataWriter };
-            
-            // var networkDataWriter = new NetworkDataWriter(recordIdentifier);
-            // _outputs = new IDataWriter[] { networkDataWriter };
+            _outputs = outputs;
 
             _dispatcherThread = new Thread(() => DispatchLoop(record))
             {

--- a/Runtime/Core/Recorder/Writer/DataDispatcher.cs
+++ b/Runtime/Core/Recorder/Writer/DataDispatcher.cs
@@ -11,10 +11,10 @@ namespace PLUME.Core.Recorder.Writer
         private bool _running;
         private Thread _dispatcherThread;
 
-        private IDataWriter<IDataWriterInfo>[] _outputs;
+        private IDataWriter[] _outputs;
         private NetworkStream _networkStream;
 
-        internal void Start(Record record, IDataWriter<IDataWriterInfo>[] outputs)
+        internal void Start(Record record, IDataWriter[] outputs)
         {
             _outputs = outputs;
 

--- a/Runtime/Core/Recorder/Writer/IDataWriter.cs
+++ b/Runtime/Core/Recorder/Writer/IDataWriter.cs
@@ -1,7 +1,9 @@
 namespace PLUME.Core.Recorder.Writer
 {
-    public interface IDataWriter
+    public interface IDataWriter<out TDataWriterInfo> where TDataWriterInfo:IDataWriterInfo
     {
+        public TDataWriterInfo Info { get; }
+
         public void WriteTimelessData(DataChunks dataChunks);
 
         public void WriteTimestampedData(DataChunksTimestamped dataChunks);
@@ -10,4 +12,7 @@ namespace PLUME.Core.Recorder.Writer
 
         public void Close();
     }
+
+    public interface IDataWriterInfo
+    {}
 }

--- a/Runtime/Core/Recorder/Writer/IDataWriter.cs
+++ b/Runtime/Core/Recorder/Writer/IDataWriter.cs
@@ -2,7 +2,7 @@ namespace PLUME.Core.Recorder.Writer
 {
     public interface IDataWriter
     {
-        public void Initialize(Record record);
+        public void SetMetaData(RecordMetadata metadata);
 
         public void WriteTimelessData(DataChunks dataChunks);
 

--- a/Runtime/Core/Recorder/Writer/IDataWriter.cs
+++ b/Runtime/Core/Recorder/Writer/IDataWriter.cs
@@ -1,8 +1,8 @@
 namespace PLUME.Core.Recorder.Writer
 {
-    public interface IDataWriter<out TDataWriterInfo> where TDataWriterInfo:IDataWriterInfo
+    public interface IDataWriter
     {
-        public TDataWriterInfo Info { get; }
+        public void Initialize(Record record);
 
         public void WriteTimelessData(DataChunks dataChunks);
 
@@ -12,7 +12,4 @@ namespace PLUME.Core.Recorder.Writer
 
         public void Close();
     }
-
-    public interface IDataWriterInfo
-    {}
 }

--- a/Runtime/Core/Recorder/Writer/NetworkDataWriter.cs
+++ b/Runtime/Core/Recorder/Writer/NetworkDataWriter.cs
@@ -8,14 +8,21 @@ using UnityEngine;
 
 namespace PLUME.Core.Recorder.Writer
 {
-    public class NetworkDataWriter : IDataWriter
+    public class NetworkDataWriter : IDataWriter<NetworkDataWriterInfo>
     {
         private readonly Stream _stream;
 
-        public NetworkDataWriter(RecordMetadata recordMetadata)
+        public NetworkDataWriterInfo Info { get; private set; }
+
+        public NetworkDataWriter(Record record, NetworkDataWriterInfo networkDataWriterInfo = null)
         {
+            if (networkDataWriterInfo == null)
+            {
+                networkDataWriterInfo = new NetworkDataWriterInfo(ipAddress: "127.0.0.1", port: 8000);
+            }
+            Info = networkDataWriterInfo;
             // Create a tcp server
-            var server = new TcpListener(IPAddress.Parse("127.0.0.1"), 8000);
+            var server = new TcpListener(IPAddress.Parse(Info.IpAddress), Info.Port);
             server.Start();
             
             var stream = server.AcceptTcpClient().GetStream();
@@ -48,6 +55,18 @@ namespace PLUME.Core.Recorder.Writer
         public void Close()
         {
             _stream.Close();
+        }
+    }
+
+    public class NetworkDataWriterInfo : IDataWriterInfo
+    {
+        public string IpAddress { get; }
+        public int Port { get; }
+
+        public NetworkDataWriterInfo(string ipAddress, int port)
+        {
+            IpAddress = ipAddress;
+            Port = port;
         }
     }
 }

--- a/Runtime/Core/Recorder/Writer/NetworkDataWriter.cs
+++ b/Runtime/Core/Recorder/Writer/NetworkDataWriter.cs
@@ -10,17 +10,9 @@ namespace PLUME.Core.Recorder.Writer
 {
     public class NetworkDataWriter : IDataWriter
     {
-        private Stream _stream;
-        private string ipAddress;
-        private int port;
+        private readonly Stream _stream;
 
         public NetworkDataWriter(string ipAddress="127.0.0.1", int port=8000)
-        {
-            this.ipAddress = ipAddress;
-            this.port = port;
-        }
-
-        public void Initialize(Record _)
         {
             // Create a tcp server
             var server = new TcpListener(IPAddress.Parse(ipAddress), port);
@@ -36,6 +28,9 @@ namespace PLUME.Core.Recorder.Writer
             
             _stream = LZ4Stream.Encode(stream, LZ4Level.L00_FAST);
         }
+
+        public void SetMetaData(RecordMetadata _)
+        {}
 
         public void WriteTimelessData(DataChunks dataChunks)
         {

--- a/Runtime/Core/Recorder/Writer/NetworkDataWriter.cs
+++ b/Runtime/Core/Recorder/Writer/NetworkDataWriter.cs
@@ -8,21 +8,22 @@ using UnityEngine;
 
 namespace PLUME.Core.Recorder.Writer
 {
-    public class NetworkDataWriter : IDataWriter<NetworkDataWriterInfo>
+    public class NetworkDataWriter : IDataWriter
     {
-        private readonly Stream _stream;
+        private Stream _stream;
+        private string ipAddress;
+        private int port;
 
-        public NetworkDataWriterInfo Info { get; private set; }
-
-        public NetworkDataWriter(Record record, NetworkDataWriterInfo networkDataWriterInfo = null)
+        public NetworkDataWriter(string ipAddress="127.0.0.1", int port=8000)
         {
-            if (networkDataWriterInfo == null)
-            {
-                networkDataWriterInfo = new NetworkDataWriterInfo(ipAddress: "127.0.0.1", port: 8000);
-            }
-            Info = networkDataWriterInfo;
+            this.ipAddress = ipAddress;
+            this.port = port;
+        }
+
+        public void Initialize(Record _)
+        {
             // Create a tcp server
-            var server = new TcpListener(IPAddress.Parse(Info.IpAddress), Info.Port);
+            var server = new TcpListener(IPAddress.Parse(ipAddress), port);
             server.Start();
             
             var stream = server.AcceptTcpClient().GetStream();
@@ -55,18 +56,6 @@ namespace PLUME.Core.Recorder.Writer
         public void Close()
         {
             _stream.Close();
-        }
-    }
-
-    public class NetworkDataWriterInfo : IDataWriterInfo
-    {
-        public string IpAddress { get; }
-        public int Port { get; }
-
-        public NetworkDataWriterInfo(string ipAddress, int port)
-        {
-            IpAddress = ipAddress;
-            Port = port;
         }
     }
 }


### PR DESCRIPTION
This PR refactors the recorder infrastructure to support configurable output data writers. The IDataWriter interface is now generic on a new IDataWriterInfo, allowing data writers to receive configuration via info objects (FileDataWriterInfo, NetworkDataWriterInfo) when instantiated. StartRecordingInternal and StartRecording accept an array of IDataWriterInfo to flexibly control recording destinations and configurations at runtime. This enables future extensibility, such as adding new writer types or enabling user selection of outputs. Default behavior remains writing to a file when no outputs are specified. Added info classes for file and network writers to contain configuration like file paths and network endpoints.

An alternative to having IDataWriterInfo is to directly pass the IDataWriter instances, and pass the record instance through an `Initialize` method.

This is primarily motivated by wanting to control when data recording starts and stops and as an extension also specify where and how the data would be recorded.

If necessary, the implementations allows adding support to configuring the writers from settings as well.

Let me know what you think about this.